### PR TITLE
Remove unused references to creator_id and updater_id

### DIFF
--- a/src/Models/Cart.php
+++ b/src/Models/Cart.php
@@ -33,8 +33,6 @@ use Tipoff\Support\Traits\HasPackageFactory;
  * // Raw Relation ID
  * @property int|null user_id
  * @property int|null location_id
- * @property int|null creator_id
- * @property int|null updater_id
  */
 class Cart extends BaseModel implements CartInterface
 {
@@ -50,8 +48,6 @@ class Cart extends BaseModel implements CartInterface
         'expires_at' => 'datetime',
         'user_id' => 'integer',
         'location_id' => 'integer',
-        'creator_id' => 'integer',
-        'updater_id' => 'integer',
     ];
 
     private static array $deductionTypes = [

--- a/src/Models/CartItem.php
+++ b/src/Models/CartItem.php
@@ -29,8 +29,6 @@ use Tipoff\Support\Traits\HasPackageFactory;
  * @property int|null rate_id
  * @property int|null fee_id
  * @property int|null tax_id
- * @property int|null creator_id
- * @property int|null updater_id
  */
 class CartItem extends BaseModel implements CartItemInterface
 {
@@ -66,8 +64,6 @@ class CartItem extends BaseModel implements CartItemInterface
         'rate_id' => 'integer',
         'fee_id' => 'integer',
         'tax_id' => 'integer',
-        'creator_id' => 'integer',
-        'updater_id' => 'integer',
     ];
 
     protected static function boot()


### PR DESCRIPTION
These models don't use the HasCreator or HasUpdater traits and the relevant fields aren't in the migrations for the corresponding tables, so we don't need the creator_id or updater_id fields to be referenced in these models.