### PR TITLE
Make Nova resource configuration dynamic based on class existence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "tipoff/fees": "dev-main",
         "tipoff/payments": "dev-main",
         "tipoff/scheduling": "dev-main",
-        "tipoff/support": "^1.3.0",
+        "tipoff/support": "1.3.0 as 1.2.7",
         "tipoff/taxes": "dev-main"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "tipoff/fees": "dev-main",
         "tipoff/payments": "dev-main",
         "tipoff/scheduling": "dev-main",
-        "tipoff/support": "dev-pdbreen/feature/nova-resources as 1.2.7",
+        "tipoff/support": "^1.3.0",
         "tipoff/taxes": "dev-main"
     },
     "require-dev": {
-        "tipoff/test-support": "dev-pdbreen/feature/nova-resources as 1.0.3"
+        "tipoff/test-support": "^1.0.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "tipoff/fees": "dev-main",
         "tipoff/payments": "dev-main",
         "tipoff/scheduling": "dev-main",
-        "tipoff/support": "^1.2.7",
+        "tipoff/support": "dev-pdbreen/feature/nova-resources as 1.2.7",
         "tipoff/taxes": "dev-main"
     },
     "require-dev": {
-        "tipoff/test-support": "^1.0.3"
+        "tipoff/test-support": "dev-pdbreen/feature/nova-resources as 1.0.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Nova/Order.php
+++ b/src/Nova/Order.php
@@ -14,9 +14,9 @@ use Laravel\Nova\Fields\MorphMany;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
-use Tipoff\Support\Nova\Resource;
+use Tipoff\Support\Nova\BaseResource;
 
-class Order extends Resource
+class Order extends BaseResource
 {
     public static $model = \Tipoff\Checkout\Models\Order::class;
 

--- a/tests/Feature/Nova/OrderResourceTest.php
+++ b/tests/Feature/Nova/OrderResourceTest.php
@@ -39,7 +39,7 @@ class OrderResourceTest extends TestCase
             'id',
             'order_number',
             'amount',
-            'created_at'
+            'created_at',
         ], $orderFields->toArray());
     }
 
@@ -66,8 +66,7 @@ class OrderResourceTest extends TestCase
             'customer',
             'location',
             'amount',
-            'created_at'
+            'created_at',
         ], $orderFields->toArray());
     }
-
 }

--- a/tests/Feature/Nova/OrderResourceTest.php
+++ b/tests/Feature/Nova/OrderResourceTest.php
@@ -21,7 +21,6 @@ class OrderResourceTest extends TestCase
         parent::setUp();
     }
 
-
     /** @test */
     public function create()
     {

--- a/tests/Feature/Nova/OrderResourceTestWithStubs.php
+++ b/tests/Feature/Nova/OrderResourceTestWithStubs.php
@@ -10,56 +10,15 @@ use Tipoff\Checkout\Models\Order;
 use Tipoff\Checkout\Tests\TestCase;
 use Tipoff\TestSupport\Models\User;
 
-class OrderResourceTest extends TestCase
+class OrderResourceTestWithStubs extends TestCase
 {
     use DatabaseTransactions;
 
-    public function setUp(): void
-    {
-        $this->stubNovaResources = false;
-
-        parent::setUp();
-    }
-
-
     /** @test */
-    public function create()
+    public function index_with_stub_resources()
     {
-        $this->actingAs(User::factory()->create());
+        $this->createStubNovaResources();
 
-        $this->getJson('nova-api/orders/creation-fields')
-            ->assertStatus(403);
-    }
-
-    /** @test */
-    public function edit()
-    {
-        $this->actingAs(User::factory()->create());
-
-        $this->getJson('nova-api/orders/creation-fields')
-            ->assertStatus(403);
-    }
-
-    /** @test */
-    public function index_no_user()
-    {
-        $this->getJson('nova-api/orders')
-            ->assertStatus(401);
-    }
-
-    /** @test */
-    public function detail_no_user()
-    {
-        /** @var Order $order */
-        $order = Order::factory()->create();
-
-        $this->getJson("nova-api/orders/{$order->id}")
-            ->assertStatus(401);
-    }
-
-    /** @test */
-    public function index_without_stub_resources()
-    {
         Order::factory()->count(4)->create();
 
         $this->actingAs(User::factory()->create());
@@ -71,18 +30,22 @@ class OrderResourceTest extends TestCase
 
         $orderFields = collect($response->json('resources')[0]['fields'])->pluck('attribute');
 
-        $this->assertCount(4, $orderFields);
+        $this->assertCount(6, $orderFields);
         $this->assertEquals([
             'id',
             'order_number',
+            'customer',
+            'location',
             'amount',
             'created_at',
         ], $orderFields->toArray());
     }
 
     /** @test */
-    public function detail_with_no_stubs()
+    public function detail_with_stubs()
     {
+        $this->createStubNovaResources();
+
         /** @var Order $order */
         $order = Order::factory()->create();
 
@@ -106,14 +69,24 @@ class OrderResourceTest extends TestCase
 
         $this->assertEquals([
             'order_number',
+            'customer',
+            'location',
             'amount',
             'total_taxes',
             'total_fees',
-            'bookings', // TODO - remove when tipoff/bookings dependency is eliminated
+            'bookings',
+            'purchasedVouchers',
+            'payments',
+            'invoices',
+            'discounts',
+            'voucher',
+            'notes',
         ], $orderFields["Order Details: {$order->order_number}"]);
 
         $this->assertEquals([
             'id',
+            'creator',
+            'created_at',
             'updated_at',
         ], $orderFields["Data Fields"]);
     }


### PR DESCRIPTION
These changes construct Nova resources dynamically based on which other nova resources exist at time of construction.  It handles both fields as well as filters, cards, lenses and actions.  Additional comments will be added to code lines.

* [x] requires updated tipoff/support before merge
* [x] requires updated tipoff/test-support before merge