### PR TITLE
Allow replacement of existing item in cart

### DIFF
--- a/src/Services/CartItem/AddToCart.php
+++ b/src/Services/CartItem/AddToCart.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tipoff\Checkout\Services\CartItem;
 
-use Tipoff\Checkout\Exceptions\CartNotValidException;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
 

--- a/src/Services/CartItem/AddToCart.php
+++ b/src/Services/CartItem/AddToCart.php
@@ -13,8 +13,11 @@ class AddToCart
     public function __invoke(CartItem $cartItem, Cart $cart): CartItem
     {
         // Ensure item is unique
-        if ($cart->findItem($cartItem->getSellable(), $cartItem->getItemId())) {
-            throw new CartNotValidException();
+        /** @var CartItem $findItem */
+        $findItem = $cart->findItem($cartItem->getSellable(), $cartItem->getItemId());
+        if ($findItem) {
+            $findItem->delete();
+            $cart->load('cartItems');
         }
 
         // Validate location is allowed

--- a/tests/Unit/Services/CartItem/UpdateInCartTest.php
+++ b/tests/Unit/Services/CartItem/UpdateInCartTest.php
@@ -6,7 +6,6 @@ namespace Tipoff\Checkout\Tests\Unit\Services\CartItem;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
-use Tipoff\Checkout\Exceptions\CartNotValidException;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;

--- a/tests/Unit/Services/CartItem/UpdateInCartTest.php
+++ b/tests/Unit/Services/CartItem/UpdateInCartTest.php
@@ -45,18 +45,4 @@ class UpdateInCartTest extends TestCase
         Event::assertDispatched(CartItemCreated::class, 1);
         Event::assertDispatched(CartItemUpdated::class, 1);
     }
-
-    /** @test */
-    public function cannot_upsert_existing_item_as_new()
-    {
-        /** @var CartItem $cartItem */
-        $cartItem = Cart::createItem($this->sellable, 'item-id', 1234, 2);
-        $this->cart->upsertItem($cartItem);
-        $this->assertCount(1, $this->cart->getItems());
-
-        $this->expectException(CartNotValidException::class);
-
-        $cartItem = Cart::createItem($this->sellable, 'item-id', 5678, 2);
-        $this->cart->upsertItem($cartItem);
-    }
 }


### PR DESCRIPTION
A policy change -- attempting to add an identical item to the cart (ie, same sellable type with same sku) will now replace the existing item instead of throwing an exception.