### PR TITLE
Add nova index, show, delete tests by role and index role location filtering test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "tipoff/authorization": "^2.5.5",
-        "tipoff/locations": "^2.6.0",
+        "tipoff/locations": "^2.7.0",
         "tipoff/statuses": "^2.0.5",
         "tipoff/support": "^1.7.2"
     },

--- a/src/Nova/Cart.php
+++ b/src/Nova/Cart.php
@@ -32,11 +32,7 @@ class Cart extends BaseCheckoutResource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if ($request->user()->hasRole([
-            'Admin',
-            'Owner',
-            'Executive',
-        ])) {
+        if ($request->user()->hasPermissionTo('all locations')) {
             return $query;
         }
 

--- a/src/Nova/Cart.php
+++ b/src/Nova/Cart.php
@@ -30,6 +30,19 @@ class Cart extends BaseCheckoutResource
         \Tipoff\Locations\Nova\Filters\Location::class,
     ];
 
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if ($request->user()->hasRole([
+            'Admin',
+            'Owner',
+            'Executive',
+        ])) {
+            return $query;
+        }
+
+        return $query->whereIn('location_id', $request->user()->locations->pluck('id'));
+    }
+
     public function fieldsForIndex(NovaRequest $request)
     {
         return array_filter([

--- a/src/Nova/CartItem.php
+++ b/src/Nova/CartItem.php
@@ -36,11 +36,7 @@ class CartItem extends BaseCheckoutResource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if ($request->user()->hasRole([
-            'Admin',
-            'Owner',
-            'Executive',
-        ])) {
+        if ($request->user()->hasPermissionTo('all locations')) {
             return $query;
         }
 

--- a/src/Nova/CartItem.php
+++ b/src/Nova/CartItem.php
@@ -34,6 +34,19 @@ class CartItem extends BaseCheckoutResource
 
     ];
 
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if ($request->user()->hasRole([
+            'Admin',
+            'Owner',
+            'Executive',
+        ])) {
+            return $query;
+        }
+
+        return $query->whereIn('location_id', $request->user()->locations->pluck('id'));
+    }
+
     public function fieldsForIndex(NovaRequest $request)
     {
         return array_filter([

--- a/src/Nova/Order.php
+++ b/src/Nova/Order.php
@@ -36,11 +36,7 @@ class Order extends BaseCheckoutResource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if ($request->user()->hasRole([
-            'Admin',
-            'Owner',
-            'Executive',
-        ])) {
+        if ($request->user()->hasPermissionTo('all locations')) {
             return $query;
         }
 

--- a/src/Nova/Order.php
+++ b/src/Nova/Order.php
@@ -34,6 +34,19 @@ class Order extends BaseCheckoutResource
         \Tipoff\Locations\Nova\Filters\Location::class,
     ];
 
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if ($request->user()->hasRole([
+            'Admin',
+            'Owner',
+            'Executive',
+        ])) {
+            return $query;
+        }
+
+        return $query->whereIn('location_id', $request->user()->locations->pluck('id'));
+    }
+
     public function fieldsForIndex(NovaRequest $request)
     {
         return array_filter([

--- a/src/Nova/OrderItem.php
+++ b/src/Nova/OrderItem.php
@@ -31,11 +31,7 @@ class OrderItem extends BaseCheckoutResource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if ($request->user()->hasRole([
-            'Admin',
-            'Owner',
-            'Executive',
-        ])) {
+        if ($request->user()->hasPermissionTo('all locations')) {
             return $query;
         }
 

--- a/src/Nova/OrderItem.php
+++ b/src/Nova/OrderItem.php
@@ -29,6 +29,19 @@ class OrderItem extends BaseCheckoutResource
 
     public static $group = 'Ecommerce';
 
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if ($request->user()->hasRole([
+            'Admin',
+            'Owner',
+            'Executive',
+        ])) {
+            return $query;
+        }
+
+        return $query->whereIn('location_id', $request->user()->locations->pluck('id'));
+    }
+
     public function fieldsForIndex(NovaRequest $request)
     {
         return [

--- a/tests/Feature/Nova/CartItemResourceTest.php
+++ b/tests/Feature/Nova/CartItemResourceTest.php
@@ -5,43 +5,173 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Feature\Nova;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Locations\Models\Location;
 
 class CartItemResourceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /** @test */
-    public function index()
+    private const NOVA_ROUTE = 'nova-api/cart-items';
+
+    /**
+     * @dataProvider dataProviderForIndexRoleLocationFilter
+     * @test
+     */
+    public function index_role_location_filter(string $role, bool $isRoleLocationFiltered)
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        $location1 = Location::factory()->create();
+        $location2 = Location::factory()->create();
+
+        CartItem::factory()->count(2)->withSellable($sellable)->create([
+            'location_id' => $location1,
+        ]);
+
+        CartItem::factory()->count(3)->withSellable($sellable)->create([
+            'location_id' => $location2,
+        ]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $user->locations()->attach($location1);
+        $this->actingAs($user);
+
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertOk();
+
+        $this->assertCount($isRoleLocationFiltered ? 2 : 5, $response->json('resources'));
+    }
+
+    public function dataProviderForIndexRoleLocationFilter()
+    {
+        return [
+            'Admin' => ['Admin', false],
+            'Owner' => ['Owner', false],
+            'Executive' => ['Executive', false],
+            'Staff' => ['Staff', true],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIndexByRole
+     * @test
+     */
+    public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
         CartItem::factory()->count(4)->withSellable($sellable)->create();
 
-        $this->actingAs(self::createPermissionedUser('view cart items', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson('nova-api/cart-items')
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertCount(4, $response->json('resources'));
+        if ($hasAccess) {
+            $this->assertCount($canIndex ? 4 : 0, $response->json('resources'));
+        }
     }
 
-    /** @test */
-    public function show()
+    public function dataProviderForIndexByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForShowByRole
+     * @test
+     */
+    public function show_by_role(?string $role, bool $hasAccess, bool $canView)
     {
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $cartItem = CartItem::factory()->withSellable($sellable)->create();
+        $model = CartItem::factory()->withSellable($sellable)->create();
 
-        $this->actingAs(self::createPermissionedUser('view cart items', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson("nova-api/cart-items/{$cartItem->id}")
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE . "/{$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertEquals($cartItem->id, $response->json('resource.id.value'));
+        if ($hasAccess && $canView) {
+            $this->assertEquals($model->id, $response->json('resource.id.value'));
+        }
+    }
+
+    public function dataProviderForShowByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForDeleteByRole
+     * @test
+     */
+    public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        $model = CartItem::factory()->withSellable($sellable)->create();
+
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
+
+        // Request never fails
+        $this->deleteJson(self::NOVA_ROUTE . "?resources[]={$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        // But deletion will only occur if user has permissions
+        $this->assertDatabaseCount('cart_items', $canDelete ? 0 : 1);
+    }
+
+    public function dataProviderForDeleteByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, false],
+            'Owner' => ['Owner', true, false],
+            'Executive' => ['Executive', true, false],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
     }
 }

--- a/tests/Feature/Nova/CartResourceTest.php
+++ b/tests/Feature/Nova/CartResourceTest.php
@@ -5,36 +5,162 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Feature\Nova;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
+use Tipoff\Checkout\Models\CartItem;
+use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Locations\Models\Location;
 
 class CartResourceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /** @test */
-    public function index()
+    private const NOVA_ROUTE = 'nova-api/carts';
+
+    /**
+     * @dataProvider dataProviderForIndexRoleLocationFilter
+     * @test
+     */
+    public function index_role_location_filter(string $role, bool $isRoleLocationFiltered)
+    {
+        $location1 = Location::factory()->create();
+        $location2 = Location::factory()->create();
+
+        Cart::factory()->count(2)->create([
+            'location_id' => $location1,
+        ]);
+
+        Cart::factory()->count(3)->create([
+            'location_id' => $location2,
+        ]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $user->locations()->attach($location1);
+        $this->actingAs($user);
+
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertOk();
+
+        $this->assertCount($isRoleLocationFiltered ? 2 : 5, $response->json('resources'));
+    }
+
+    public function dataProviderForIndexRoleLocationFilter()
+    {
+        return [
+            'Admin' => ['Admin', false],
+            'Owner' => ['Owner', false],
+            'Executive' => ['Executive', false],
+            'Staff' => ['Staff', true],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIndexByRole
+     * @test
+     */
+    public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
         Cart::factory()->count(4)->create();
 
-        $this->actingAs(self::createPermissionedUser('view carts', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson('nova-api/carts')
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertCount(4, $response->json('resources'));
+        if ($hasAccess) {
+            $this->assertCount($canIndex ? 4 : 0, $response->json('resources'));
+        }
     }
 
-    /** @test */
-    public function show()
+    public function dataProviderForIndexByRole()
     {
-        $cart = Cart::factory()->create();
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
+    }
 
-        $this->actingAs(self::createPermissionedUser('view carts', true));
+    /**
+     * @dataProvider dataProviderForShowByRole
+     * @test
+     */
+    public function show_by_role(?string $role, bool $hasAccess, bool $canView)
+    {
+        $model = Cart::factory()->create();
 
-        $response = $this->getJson("nova-api/carts/{$cart->id}")
-            ->assertOk();
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $this->assertEquals($cart->id, $response->json('resource.id.value'));
+        $response = $this->getJson(self::NOVA_ROUTE . "/{$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        if ($hasAccess && $canView) {
+            $this->assertEquals($model->id, $response->json('resource.id.value'));
+        }
+    }
+
+    public function dataProviderForShowByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForDeleteByRole
+     * @test
+     */
+    public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
+    {
+        $model = Cart::factory()->create();
+
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
+
+        // Request never fails
+        $this->deleteJson(self::NOVA_ROUTE . "?resources[]={$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        // But deletion will only occur if user has permissions
+        $this->assertDatabaseCount('carts', $canDelete ? 0 : 1);
+    }
+
+    public function dataProviderForDeleteByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, false],
+            'Owner' => ['Owner', true, false],
+            'Executive' => ['Executive', true, false],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
     }
 }

--- a/tests/Feature/Nova/CartResourceTest.php
+++ b/tests/Feature/Nova/CartResourceTest.php
@@ -7,8 +7,6 @@ namespace Tipoff\Checkout\Tests\Feature\Nova;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
-use Tipoff\Checkout\Models\CartItem;
-use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
 use Tipoff\Locations\Models\Location;
 

--- a/tests/Feature/Nova/OrderItemResourceTest.php
+++ b/tests/Feature/Nova/OrderItemResourceTest.php
@@ -5,43 +5,173 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Feature\Nova;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\OrderItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Locations\Models\Location;
 
 class OrderItemResourceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /** @test */
-    public function index()
+    private const NOVA_ROUTE = 'nova-api/order-items';
+
+    /**
+     * @dataProvider dataProviderForIndexRoleLocationFilter
+     * @test
+     */
+    public function index_role_location_filter(string $role, bool $isRoleLocationFiltered)
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        $location1 = Location::factory()->create();
+        $location2 = Location::factory()->create();
+
+        OrderItem::factory()->count(2)->withSellable($sellable)->create([
+            'location_id' => $location1,
+        ]);
+
+        OrderItem::factory()->count(3)->withSellable($sellable)->create([
+            'location_id' => $location2,
+        ]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $user->locations()->attach($location1);
+        $this->actingAs($user);
+
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertOk();
+
+        $this->assertCount($isRoleLocationFiltered ? 2 : 5, $response->json('resources'));
+    }
+
+    public function dataProviderForIndexRoleLocationFilter()
+    {
+        return [
+            'Admin' => ['Admin', false],
+            'Owner' => ['Owner', false],
+            'Executive' => ['Executive', false],
+            'Staff' => ['Staff', true],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIndexByRole
+     * @test
+     */
+    public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
         OrderItem::factory()->count(4)->withSellable($sellable)->create();
 
-        $this->actingAs(self::createPermissionedUser('view order items', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson('nova-api/order-items')
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertCount(4, $response->json('resources'));
+        if ($hasAccess) {
+            $this->assertCount($canIndex ? 4 : 0, $response->json('resources'));
+        }
     }
 
-    /** @test */
-    public function show()
+    public function dataProviderForIndexByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForShowByRole
+     * @test
+     */
+    public function show_by_role(?string $role, bool $hasAccess, bool $canView)
     {
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $orderItem = OrderItem::factory()->withSellable($sellable)->create();
+        $model = OrderItem::factory()->withSellable($sellable)->create();
 
-        $this->actingAs(self::createPermissionedUser('view order items', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson("nova-api/order-items/{$orderItem->id}")
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE . "/{$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertEquals($orderItem->id, $response->json('resource.id.value'));
+        if ($hasAccess && $canView) {
+            $this->assertEquals($model->id, $response->json('resource.id.value'));
+        }
+    }
+
+    public function dataProviderForShowByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForDeleteByRole
+     * @test
+     */
+    public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        $model = OrderItem::factory()->withSellable($sellable)->create();
+
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
+
+        // Request never fails
+        $this->deleteJson(self::NOVA_ROUTE . "?resources[]={$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        // But deletion will only occur if user has permissions
+        $this->assertDatabaseCount('order_items', $canDelete ? 0 : 1);
+    }
+
+    public function dataProviderForDeleteByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, false],
+            'Owner' => ['Owner', true, false],
+            'Executive' => ['Executive', true, false],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
     }
 }

--- a/tests/Feature/Nova/OrderResourceTest.php
+++ b/tests/Feature/Nova/OrderResourceTest.php
@@ -5,36 +5,160 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Feature\Nova;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Order;
 use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Locations\Models\Location;
 
 class OrderResourceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /** @test */
-    public function index()
+    private const NOVA_ROUTE = 'nova-api/orders';
+
+    /**
+     * @dataProvider dataProviderForIndexRoleLocationFilter
+     * @test
+     */
+    public function index_role_location_filter(string $role, bool $isRoleLocationFiltered)
+    {
+        $location1 = Location::factory()->create();
+        $location2 = Location::factory()->create();
+
+        Order::factory()->count(2)->create([
+            'location_id' => $location1,
+        ]);
+
+        Order::factory()->count(3)->create([
+            'location_id' => $location2,
+        ]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $user->locations()->attach($location1);
+        $this->actingAs($user);
+
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertOk();
+
+        $this->assertCount($isRoleLocationFiltered ? 2 : 5, $response->json('resources'));
+    }
+
+    public function dataProviderForIndexRoleLocationFilter()
+    {
+        return [
+            'Admin' => ['Admin', false],
+            'Owner' => ['Owner', false],
+            'Executive' => ['Executive', false],
+            'Staff' => ['Staff', true],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIndexByRole
+     * @test
+     */
+    public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
         Order::factory()->count(4)->create();
 
-        $this->actingAs(self::createPermissionedUser('view orders', true));
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $response = $this->getJson('nova-api/orders')
-            ->assertOk();
+        $response = $this->getJson(self::NOVA_ROUTE)
+            ->assertStatus($hasAccess ? 200 : 403);
 
-        $this->assertCount(4, $response->json('resources'));
+        if ($hasAccess) {
+            $this->assertCount($canIndex ? 4 : 0, $response->json('resources'));
+        }
     }
 
-    /** @test */
-    public function show()
+    public function dataProviderForIndexByRole()
     {
-        $order = Order::factory()->create();
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
+    }
 
-        $this->actingAs(self::createPermissionedUser('view orders', true));
+    /**
+     * @dataProvider dataProviderForShowByRole
+     * @test
+     */
+    public function show_by_role(?string $role, bool $hasAccess, bool $canView)
+    {
+        $model = Order::factory()->create();
 
-        $response = $this->getJson("nova-api/orders/{$order->id}")
-            ->assertOk();
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
 
-        $this->assertEquals($order->id, $response->json('resource.id.value'));
+        $response = $this->getJson(self::NOVA_ROUTE . "/{$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        if ($hasAccess && $canView) {
+            $this->assertEquals($model->id, $response->json('resource.id.value'));
+        }
+    }
+
+    public function dataProviderForShowByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, true],
+            'Owner' => ['Owner', true, true],
+            'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForDeleteByRole
+     * @test
+     */
+    public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
+    {
+        $model = Order::factory()->create();
+
+        $user = User::factory()->create();
+        if ($role) {
+            $user->assignRole($role);
+        }
+        $this->actingAs($user);
+
+        // Request never fails
+        $this->deleteJson(self::NOVA_ROUTE . "?resources[]={$model->id}")
+            ->assertStatus($hasAccess ? 200 : 403);
+
+        // But deletion will only occur if user has permissions
+        $this->assertDatabaseCount('orders', $canDelete ? 0 : 1);
+    }
+
+    public function dataProviderForDeleteByRole()
+    {
+        return [
+            'Admin' => ['Admin', true, false],
+            'Owner' => ['Owner', true, false],
+            'Executive' => ['Executive', true, false],
+            'Staff' => ['Staff', true, false],
+            'Former Staff' => ['Former Staff', true, false],
+            'Customer' => ['Customer', true, false],
+            'No Role' => [null, true, false],
+        ];
     }
 }


### PR DESCRIPTION
Brings across role based nova resource checks for index, show and delete and adds an additional role based test for index the confirms resources are / are not filtered automatically by location when appropriate.

NOTE: the index filtering by location in Nova doesn't actually prevent those users from interacting with resources that are in different locations.  To properly enforce that a new permission is needed and all of the policies need to become smarter.  Here's how I'd do it:
* create a new "all locations" permission that is added to the roles that shouldn't be location restricted
* modify policies for any model that is location aware to check the user has the permission for the action and user has the "all locations" permission OR the user has access to the location the model is in 

Edit:  If you go this route, the index location filtering in Nova could change from a role based exclusion to a permission based exclusion.  If the user has the "all locations" permission, the location filtering isn't applied.