### PR TITLE
Update Nova test setup to ensure user / resource locations are aligned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/authorization": "^2.5.5",
+        "tipoff/authorization": "dev-pdbreen/bugfix/enforce-admin-access-in-tests as 2.6.1",
         "tipoff/locations": "^2.7.1",
         "tipoff/statuses": "^2.1.0",
-        "tipoff/support": "^1.8.2"
+        "tipoff/support": "dev-pdbreen/bugfix/fix-nova-class as 1.8.4"
     },
     "require-dev": {
         "tipoff/test-support": "^1.3.0"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/authorization": "dev-pdbreen/bugfix/enforce-admin-access-in-tests as 2.6.1",
+        "tipoff/authorization": "^2.6.2",
         "tipoff/locations": "^2.7.1",
         "tipoff/statuses": "^2.1.0",
-        "tipoff/support": "dev-pdbreen/bugfix/fix-nova-class as 1.8.4"
+        "tipoff/support": "^1.8.5"
     },
     "require-dev": {
         "tipoff/test-support": "^1.3.0"

--- a/tests/Feature/Nova/CartItemResourceTest.php
+++ b/tests/Feature/Nova/CartItemResourceTest.php
@@ -65,9 +65,14 @@ class CartItemResourceTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        CartItem::factory()->count(4)->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        CartItem::factory()->count(4)->withSellable($sellable)->create([
+            'location_id' => $location,
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -87,10 +92,10 @@ class CartItemResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
-            'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Staff' => ['Staff', true, true],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 
@@ -100,12 +105,19 @@ class CartItemResourceTest extends TestCase
      */
     public function show_by_role(?string $role, bool $hasAccess, bool $canView)
     {
+        $this->logToStderr();
+
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $model = CartItem::factory()->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        $model = CartItem::factory()->withSellable($sellable)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -125,6 +137,7 @@ class CartItemResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
             'Former Staff' => ['Former Staff', false, false],
             'Customer' => ['Customer', false, false],
             'No Role' => [null, false, false],
@@ -140,9 +153,14 @@ class CartItemResourceTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $model = CartItem::factory()->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        $model = CartItem::factory()->withSellable($sellable)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -163,9 +181,9 @@ class CartItemResourceTest extends TestCase
             'Owner' => ['Owner', true, false],
             'Executive' => ['Executive', true, false],
             'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 }

--- a/tests/Feature/Nova/CartItemResourceTest.php
+++ b/tests/Feature/Nova/CartItemResourceTest.php
@@ -113,7 +113,7 @@ class CartItemResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = CartItem::factory()->withSellable($sellable)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -156,7 +156,7 @@ class CartItemResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = CartItem::factory()->withSellable($sellable)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();

--- a/tests/Feature/Nova/CartResourceTest.php
+++ b/tests/Feature/Nova/CartResourceTest.php
@@ -59,7 +59,7 @@ class CartResourceTest extends TestCase
         $location = Location::factory()->create();
 
         Cart::factory()->count(4)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -99,7 +99,7 @@ class CartResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = Cart::factory()->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -139,7 +139,7 @@ class CartResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = Cart::factory()->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();

--- a/tests/Feature/Nova/CartResourceTest.php
+++ b/tests/Feature/Nova/CartResourceTest.php
@@ -56,9 +56,14 @@ class CartResourceTest extends TestCase
      */
     public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
-        Cart::factory()->count(4)->create();
+        $location = Location::factory()->create();
+
+        Cart::factory()->count(4)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -78,7 +83,7 @@ class CartResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
-            'Staff' => ['Staff', true, false],
+            'Staff' => ['Staff', true, true],
             'Former Staff' => ['Former Staff', false, false],
             'Customer' => ['Customer', false, false],
             'No Role' => [null, false, false],
@@ -91,9 +96,14 @@ class CartResourceTest extends TestCase
      */
     public function show_by_role(?string $role, bool $hasAccess, bool $canView)
     {
-        $model = Cart::factory()->create();
+        $location = Location::factory()->create();
+
+        $model = Cart::factory()->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -126,9 +136,14 @@ class CartResourceTest extends TestCase
      */
     public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
     {
-        $model = Cart::factory()->create();
+        $location = Location::factory()->create();
+
+        $model = Cart::factory()->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }

--- a/tests/Feature/Nova/OrderItemResourceTest.php
+++ b/tests/Feature/Nova/OrderItemResourceTest.php
@@ -63,9 +63,14 @@ class OrderItemResourceTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        OrderItem::factory()->count(4)->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        OrderItem::factory()->count(4)->withSellable($sellable)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -85,10 +90,10 @@ class OrderItemResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
-            'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Staff' => ['Staff', true, true],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 
@@ -101,9 +106,14 @@ class OrderItemResourceTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $model = OrderItem::factory()->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        $model = OrderItem::factory()->withSellable($sellable)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -123,6 +133,7 @@ class OrderItemResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
+            'Staff' => ['Staff', true, false],
             'Former Staff' => ['Former Staff', false, false],
             'Customer' => ['Customer', false, false],
             'No Role' => [null, false, false],
@@ -138,9 +149,14 @@ class OrderItemResourceTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $model = OrderItem::factory()->withSellable($sellable)->create();
+        $location = Location::factory()->create();
+
+        $model = OrderItem::factory()->withSellable($sellable)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -161,9 +177,9 @@ class OrderItemResourceTest extends TestCase
             'Owner' => ['Owner', true, false],
             'Executive' => ['Executive', true, false],
             'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 }

--- a/tests/Feature/Nova/OrderItemResourceTest.php
+++ b/tests/Feature/Nova/OrderItemResourceTest.php
@@ -66,7 +66,7 @@ class OrderItemResourceTest extends TestCase
         $location = Location::factory()->create();
 
         OrderItem::factory()->count(4)->withSellable($sellable)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -109,7 +109,7 @@ class OrderItemResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = OrderItem::factory()->withSellable($sellable)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -152,7 +152,7 @@ class OrderItemResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = OrderItem::factory()->withSellable($sellable)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();

--- a/tests/Feature/Nova/OrderResourceTest.php
+++ b/tests/Feature/Nova/OrderResourceTest.php
@@ -56,9 +56,14 @@ class OrderResourceTest extends TestCase
      */
     public function index_by_role(?string $role, bool $hasAccess, bool $canIndex)
     {
-        Order::factory()->count(4)->create();
+        $location = Location::factory()->create();
+
+        Order::factory()->count(4)->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -78,10 +83,10 @@ class OrderResourceTest extends TestCase
             'Admin' => ['Admin', true, true],
             'Owner' => ['Owner', true, true],
             'Executive' => ['Executive', true, true],
-            'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Staff' => ['Staff', true, true],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 
@@ -91,9 +96,14 @@ class OrderResourceTest extends TestCase
      */
     public function show_by_role(?string $role, bool $hasAccess, bool $canView)
     {
-        $model = Order::factory()->create();
+        $location = Location::factory()->create();
+
+        $model = Order::factory()->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -126,9 +136,14 @@ class OrderResourceTest extends TestCase
      */
     public function delete_by_role(?string $role, bool $hasAccess, bool $canDelete)
     {
-        $model = Order::factory()->create();
+        $location = Location::factory()->create();
+
+        $model = Order::factory()->create([
+            'location_id' => $location
+        ]);
 
         $user = User::factory()->create();
+        $user->locations()->attach($location);
         if ($role) {
             $user->assignRole($role);
         }
@@ -149,9 +164,9 @@ class OrderResourceTest extends TestCase
             'Owner' => ['Owner', true, false],
             'Executive' => ['Executive', true, false],
             'Staff' => ['Staff', true, false],
-            'Former Staff' => ['Former Staff', true, false],
-            'Customer' => ['Customer', true, false],
-            'No Role' => [null, true, false],
+            'Former Staff' => ['Former Staff', false, false],
+            'Customer' => ['Customer', false, false],
+            'No Role' => [null, false, false],
         ];
     }
 }

--- a/tests/Feature/Nova/OrderResourceTest.php
+++ b/tests/Feature/Nova/OrderResourceTest.php
@@ -59,7 +59,7 @@ class OrderResourceTest extends TestCase
         $location = Location::factory()->create();
 
         Order::factory()->count(4)->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -99,7 +99,7 @@ class OrderResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = Order::factory()->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();
@@ -139,7 +139,7 @@ class OrderResourceTest extends TestCase
         $location = Location::factory()->create();
 
         $model = Order::factory()->create([
-            'location_id' => $location
+            'location_id' => $location,
         ]);
 
         $user = User::factory()->create();


### PR DESCRIPTION
* [x] requires updated tipoff/authorization that enforces `access admin` during testing
* [x] requires updated tipoff/support to prevent errors in different package failing nova tests

This includes a proper fix for testing Nova roles when locations are involved.  The test setup needs to ensure the resource and user locations are aligned - or not - depending on the test.