### PR TITLE
Change cart ownership from User to EmailAddress #85

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,14 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/authorization": "^2.7.0",
+        "tipoff/addresses": "dev-pdbreen/bugfix/create-domestic-address as 2.6.0",
+        "tipoff/authorization": "dev-pdbreen/feature/checkout-85 as 2.7.0",
         "tipoff/locations": "^2.7.1",
         "tipoff/statuses": "^2.1.0",
         "tipoff/support": "^1.8.7"
     },
     "require-dev": {
-        "tipoff/test-support": "^1.4.0"
+        "tipoff/test-support": "dev-pdbreen/feature/checkout-85 as 1.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/authorization": "dev-pdbreen/feature/checkout-85 as 2.7.0",
-        "tipoff/locations": "dev-pdbreen/bugfix/kick-the-can as 2.8.0",
+        "tipoff/authorization": "^2.7.1",
+        "tipoff/locations": "^2.8.1",
         "tipoff/statuses": "^2.1.0",
         "tipoff/support": "^1.8.8"
     },
     "require-dev": {
-        "tipoff/test-support": "^1.4.1"
+        "tipoff/test-support": "^1.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/addresses": "dev-pdbreen/bugfix/create-domestic-address as 2.6.0",
         "tipoff/authorization": "dev-pdbreen/feature/checkout-85 as 2.7.0",
-        "tipoff/locations": "^2.7.1",
+        "tipoff/locations": "^2.8.0",
         "tipoff/statuses": "^2.1.0",
         "tipoff/support": "^1.8.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "tipoff/authorization": "dev-pdbreen/feature/checkout-85 as 2.7.0",
-        "tipoff/locations": "^2.8.0",
+        "tipoff/locations": "dev-pdbreen/bugfix/kick-the-can as 2.8.0",
         "tipoff/statuses": "^2.1.0",
         "tipoff/support": "^1.8.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "tipoff/authorization": "dev-pdbreen/feature/checkout-85 as 2.7.0",
         "tipoff/locations": "^2.8.0",
         "tipoff/statuses": "^2.1.0",
-        "tipoff/support": "^1.8.7"
+        "tipoff/support": "^1.8.8"
     },
     "require-dev": {
-        "tipoff/test-support": "dev-pdbreen/feature/checkout-85 as 1.4.0"
+        "tipoff/test-support": "^1.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/database/factories/CartFactory.php
+++ b/database/factories/CartFactory.php
@@ -24,7 +24,7 @@ class CartFactory extends Factory
     public function definition()
     {
         return [
-            'user_id'    => randomOrCreate(app('user')),
+            'email_address_id'    => randomOrCreate(app('email_address')),
             'creator_id' => randomOrCreate(app('user')),
             'updater_id' => randomOrCreate(app('user')),
         ];

--- a/database/migrations/2020_05_05_050000_create_carts_table.php
+++ b/database/migrations/2020_05_05_050000_create_carts_table.php
@@ -13,7 +13,7 @@ class CreateCartsTable extends Migration
     {
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(app('user'));
+            $table->foreignIdFor(app('email_address'));
 
             $table->foreignIdFor(Order::class)->nullable();
 

--- a/src/Exceptions/CartNotValidException.php
+++ b/src/Exceptions/CartNotValidException.php
@@ -18,6 +18,11 @@ class CartNotValidException extends \InvalidArgumentException implements Checkou
         return new static('Cart contains 1 or more expired items.', $code, $previous);
     }
 
+    public static function noUserExists($code = 0, Throwable $previous = null): self
+    {
+        return new static('Email address is not associated with a user.', $code, $previous);
+    }
+
     public static function pricingHasChanged($code = 0, Throwable $previous = null): self
     {
         return new static('Cart pricing has changed.', $code, $previous);

--- a/src/Http/Controllers/Api/CartApplyCodeController.php
+++ b/src/Http/Controllers/Api/CartApplyCodeController.php
@@ -21,7 +21,7 @@ class CartApplyCodeController extends BaseApiController
 
     public function __invoke(ApplyCodeRequest $request): JsonResponse
     {
-        $cart = Cart::activeCart($request->user()->id);
+        $cart = Cart::activeCart($request->getEmailAddressId());
 
         $cart->applyCode($request->code);
 

--- a/src/Http/Controllers/Api/CartController.php
+++ b/src/Http/Controllers/Api/CartController.php
@@ -22,7 +22,7 @@ class CartController extends BaseApiController
 
     public function show(ShowRequest $request): JsonResponse
     {
-        $cart = $request->user() ? Cart::activeCart($request->user()->id) : null;
+        $cart = $request->getEmailAddressId() ? Cart::activeCart($request->getEmailAddressId()) : null;
 
         return fractal($cart, $this->transformer)
             ->respond();
@@ -30,9 +30,9 @@ class CartController extends BaseApiController
 
     public function destroy(DestroyRequest $request): JsonResponse
     {
-        if ($request->user()) {
+        if ($emailAddressId = $request->getEmailAddressId()) {
             /** @var Cart $cart */
-            $cart = Cart::activeCart($request->user()->id);
+            $cart = Cart::activeCart($emailAddressId);
             $cart->delete();
         }
 

--- a/src/Http/Controllers/Api/CartItemController.php
+++ b/src/Http/Controllers/Api/CartItemController.php
@@ -66,7 +66,7 @@ class CartItemController extends BaseApiController
 
     public function show(ShowRequest $request, CartItem $cartItem): JsonResponse
     {
-        if (!$cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
+        if (! $cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
             throw new AuthorizationException();
         }
 
@@ -76,7 +76,7 @@ class CartItemController extends BaseApiController
 
     public function update(UpdateRequest $request, CartItem $cartItem): JsonResponse
     {
-        if (!$cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
+        if (! $cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
             throw new AuthorizationException();
         }
 
@@ -89,7 +89,7 @@ class CartItemController extends BaseApiController
 
     public function destroy(DestroyRequest $request, CartItem $cartItem): JsonResponse
     {
-        if (!$cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
+        if (! $cartItem->isOwnerByEmailAddressId($request->getEmailAddressId())) {
             throw new AuthorizationException();
         }
 

--- a/src/Http/Controllers/Api/CartPurchaseController.php
+++ b/src/Http/Controllers/Api/CartPurchaseController.php
@@ -22,7 +22,7 @@ class CartPurchaseController extends BaseApiController
 
     public function __invoke(PurchaseRequest $request): JsonResponse
     {
-        $cart = Cart::activeCart($request->user()->id);
+        $cart = Cart::activeCart($request->getEmailAddressId());
 
         $order = DB::transaction(function () use ($cart) {
             // Final check all is good to go

--- a/src/Http/Requests/Api/Cart/CartRequest.php
+++ b/src/Http/Requests/Api/Cart/CartRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tipoff\Checkout\Http\Requests\Api\Cart;
 
+use Illuminate\Support\Facades\Auth;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Support\Http\Requests\BaseApiRequest;
 
@@ -12,6 +14,24 @@ abstract class CartRequest extends BaseApiRequest
     public function getModelClass(): string
     {
         return Cart::class;
+    }
+
+    public function getEmailAddressId(): ?int
+    {
+        if (Auth::guard('email')->check()) {
+            return (int) Auth::guard('email')->id();
+        }
+
+        if (Auth::guard('web')->check()) {
+            /** @var User $user */
+            $user = Auth::guard('web')->user();
+
+            $emailAddress = $user->getPrimaryEmailAddress();
+
+            return $emailAddress ? $emailAddress->id : null;
+        }
+
+        return null;
     }
 
     public function authorize()

--- a/src/Http/Requests/Api/Cart/PurchaseRequest.php
+++ b/src/Http/Requests/Api/Cart/PurchaseRequest.php
@@ -14,7 +14,7 @@ class PurchaseRequest extends CartRequest
     {
         $validator->after(function ($validator) {
             /** @var Cart|null $cart */
-            $cart = auth()->id() ? Cart::activeCart(auth()->id()) : null;
+            $cart = $this->getEmailAddressId() ? Cart::activeCart($this->getEmailAddressId()) : null;
             $this->validateCartIsPurchasable($cart, $validator);
         });
     }

--- a/src/Http/Requests/Api/CartItem/CartItemRequest.php
+++ b/src/Http/Requests/Api/CartItem/CartItemRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tipoff\Checkout\Http\Requests\Api\CartItem;
 
+use Illuminate\Support\Facades\Auth;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Support\Http\Requests\BaseApiRequest;
 
@@ -12,6 +14,24 @@ abstract class CartItemRequest extends BaseApiRequest
     public function getModelClass(): string
     {
         return CartItem::class;
+    }
+
+    public function getEmailAddressId(): ?int
+    {
+        if (Auth::guard('email')->check()) {
+            return (int) Auth::guard('email')->id();
+        }
+
+        if (Auth::guard('web')->check()) {
+            /** @var User $user */
+            $user = Auth::guard('web')->user();
+
+            $emailAddress = $user->getPrimaryEmailAddress();
+
+            return $emailAddress ? $emailAddress->id : null;
+        }
+
+        return null;
     }
 
     public function rules()

--- a/src/Models/CartItem.php
+++ b/src/Models/CartItem.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Tipoff\Checkout\Models\Traits\IsItem;
 use Tipoff\Support\Contracts\Checkout\CartInterface;
 use Tipoff\Support\Contracts\Checkout\CartItemInterface;
-use Tipoff\Support\Contracts\Models\UserInterface;
 use Tipoff\Support\Events\Checkout\CartItemCreated;
 use Tipoff\Support\Events\Checkout\CartItemRemoved;
 use Tipoff\Support\Events\Checkout\CartItemUpdated;

--- a/src/Models/CartItem.php
+++ b/src/Models/CartItem.php
@@ -112,22 +112,18 @@ class CartItem extends BaseModel implements CartItemInterface
 
     //region PERMISSIONS
 
-    public function scopeVisibleBy(Builder $query, UserInterface $user): Builder
+    public function scopeVisibleByEmailAddressId(Builder $query, int $emailAddressId): Builder
     {
-        return $query->whereHas('cart', function (Builder $q) use ($user) {
-            $q->visibleBy($user);
+        return $query->whereHas('cart', function (Builder $q) use ($emailAddressId) {
+            $q->visibleByEmailAddressId($emailAddressId);
         });
     }
 
-    public function isOwner(UserInterface $user): bool
+    public function isOwnerByEmailAddressId(int $emailAddressId): bool
     {
-        if ($userId = $user->getId()) {
-            $cart = Cart::activeCart($userId);
+        $cart = Cart::activeCart($emailAddressId);
 
-            return $this->cart_id === $cart->getId();
-        }
-
-        return false;
+        return $this->cart_id === $cart->getId();
     }
 
     //endregion

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Enums\OrderStatus;
 use Tipoff\Checkout\Filters\ItemFilter;
 use Tipoff\Checkout\Models\Traits\IsItemContainer;
@@ -25,6 +26,7 @@ use Tipoff\Support\Traits\HasPackageFactory;
 /**
  * @property string order_number
  * // Relations
+ * @property User user
  * @property Cart cart
  * @property Collection orderItems
  * @property Collection invoices
@@ -32,6 +34,7 @@ use Tipoff\Support\Traits\HasPackageFactory;
  * @property Collection vouchers
  * @property Collection discounts
  * @property Collection notes
+ * @property int user_id
  */
 class Order extends BaseModel implements OrderInterface
 {
@@ -65,7 +68,7 @@ class Order extends BaseModel implements OrderInterface
         // Build by field to avoid fillable permissions
         $order = new static;
 
-        $order->user()->associate($cart->user);
+        $order->user()->associate($cart->emailAddress->user);
         $order->shipping = $cart->getShipping();
         $order->item_amount_total = $cart->getItemAmountTotal();
         $order->discounts = $cart->getDiscounts();
@@ -106,6 +109,11 @@ class Order extends BaseModel implements OrderInterface
     }
 
     //region RELATIONSHIPS
+
+    public function user()
+    {
+        return $this->belongsTo(app('user'));
+    }
 
     public function orderItems()
     {
@@ -173,6 +181,11 @@ class Order extends BaseModel implements OrderInterface
     //endregion
 
     //region INTERFACE
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
 
     public static function itemFilter(): ItemFilter
     {

--- a/src/Models/Traits/IsItemContainer.php
+++ b/src/Models/Traits/IsItemContainer.php
@@ -11,7 +11,6 @@ use Tipoff\Addresses\Traits\HasAddresses;
 use Tipoff\Checkout\Enums\AddressTypes;
 use Tipoff\Checkout\Objects\ContainerPricingDetail;
 use Tipoff\Support\Contracts\Checkout\BaseItemInterface;
-use Tipoff\Support\Contracts\Models\UserInterface;
 use Tipoff\Support\Contracts\Sellable\Fee;
 use Tipoff\Support\Objects\DiscountableValue;
 use Tipoff\Support\Traits\HasCreator;

--- a/src/Models/Traits/IsItemContainer.php
+++ b/src/Models/Traits/IsItemContainer.php
@@ -27,10 +27,8 @@ use Tipoff\Support\Traits\HasUpdater;
  * @property Carbon created_at
  * @property Carbon updated_at
  * // Relations
- * @property mixed user
  * @property mixed location
  * // Raw Relation ID
- * @property int|null user_id
  * @property int|null location_id
  * @property int|null creator_id
  * @property int|null updater_id
@@ -49,11 +47,6 @@ trait IsItemContainer
     }
 
     //region RELATIONSHIPS
-
-    public function user()
-    {
-        return $this->belongsTo(app('user'));
-    }
 
     public function location()
     {
@@ -129,11 +122,6 @@ trait IsItemContainer
     //endregion
 
     //region INTERFACE IMPLEMENTATION
-
-    public function getUser(): UserInterface
-    {
-        return $this->user;
-    }
 
     public function getItemAmountTotal(): DiscountableValue
     {

--- a/src/Nova/Cart.php
+++ b/src/Nova/Cart.php
@@ -43,7 +43,7 @@ class Cart extends BaseCheckoutResource
     {
         return array_filter([
             ID::make()->sortable(),
-            nova('user') ? BelongsTo::make('Customer', 'user', nova('user'))->sortable() : null,
+            nova('email_address') ? BelongsTo::make('Email Address', 'emailAddress', nova('email_address'))->sortable() : null,
             nova('location') ? BelongsTo::make('Location', 'location', nova('location'))->sortable() : null,
             Currency::make('Item Total', 'item_amount_total')->asMinorUnits()->sortable(),
             Date::make('Created', 'created_at')->sortable()->exceptOnForms(),
@@ -65,9 +65,9 @@ class Cart extends BaseCheckoutResource
             nova('discount') ? HasMany::make('Discounts', 'discounts', nova('discount')) : null,
             nova('voucher') ? HasMany::make('Vouchers', 'voucher', nova('voucher')) : null,
             nova('location') ? BelongsTo::make('Location', 'location', nova('location')) : null,
-            nova('user') ? BelongsTo::make('User', 'user', nova('user'))->searchable() : null,
+            nova('email_address') ? BelongsTo::make('Email Address', 'emailAddress', nova('email_address'))->searchable() : null,
             nova('order') ? BelongsTo::make('Order', 'order', nova('order'))->nullable() : null,
-            HasMany::make('Cart items', 'cart items', CartItem::class)->nullable(),
+            HasMany::make('Cart items', 'cartItems', CartItem::class)->nullable(),
 
             new Panel('Data Fields', $this->dataFields()),
         ]);

--- a/src/Policies/CartItemPolicy.php
+++ b/src/Policies/CartItemPolicy.php
@@ -21,7 +21,7 @@ class CartItemPolicy
 
     public function view(UserInterface $user, CartItem $cartItem): bool
     {
-        return $cartItem->isOwner($user) || $this->hasLocationPermission($user, 'view cart items', $cartItem->location_id);
+        return $this->hasLocationPermission($user, 'view cart items', $cartItem->location_id);
     }
 
     public function create(UserInterface $user): bool

--- a/src/Policies/CartPolicy.php
+++ b/src/Policies/CartPolicy.php
@@ -22,7 +22,7 @@ class CartPolicy
     public function view(UserInterface $user, Cart $cart): bool
     {
         /** @psalm-suppress  UndefinedMagicPropertyFetch */
-        return $cart->isOwner($user) || $this->hasLocationPermission($user, 'view carts', $cart->location_id);
+        return $this->hasLocationPermission($user, 'view carts', $cart->location_id);
     }
 
     public function create(UserInterface $user): bool

--- a/src/Services/Cart/VerifyPurchasable.php
+++ b/src/Services/Cart/VerifyPurchasable.php
@@ -25,6 +25,7 @@ class VerifyPurchasable
 
             $this->verifyNotEmpty($cart)
                 ->verifyNoExpiredItems($cart)
+                ->verifyUser($cart)
                 ->verifyItems($cart)
                 ->verifyNoPriceChange($cart);
         });
@@ -47,6 +48,16 @@ class VerifyPurchasable
         // All items must be active
         if ($cart->cartItems->first->isExpired()) {
             throw CartNotValidException::cartHasExpiredItems();
+        }
+
+        return $this;
+    }
+
+    private function verifyUser(Cart $cart): self
+    {
+        // User must exist for email
+        if (empty($cart->emailAddress->user)) {
+            throw CartNotValidException::noUserExists();
         }
 
         return $this;

--- a/src/Transformers/BaseItemContainerTransformer.php
+++ b/src/Transformers/BaseItemContainerTransformer.php
@@ -42,7 +42,6 @@ abstract class BaseItemContainerTransformer extends BaseTransformer
             'credits' => $container->getCredits(),
             'codes' => $container->getCodes(),
             'tax' => $container->getTax(),
-            'user_id' => $container->getUser()->getId(),
             'location_id' => $container->getLocationId(),
             'creator_id' => $container->creator_id,
             'updater_id' => $container->updater_id,

--- a/src/Transformers/CartTransformer.php
+++ b/src/Transformers/CartTransformer.php
@@ -22,6 +22,7 @@ class CartTransformer extends BaseItemContainerTransformer
         /** @var Cart $cart */
         return array_merge(parent::transform($cart), [
             'expires_at' => $cart->getExpiresAt(),
+            'email_address_id' => $cart->emailAddress->id,
         ]);
     }
 }

--- a/src/Transformers/OrderTransformer.php
+++ b/src/Transformers/OrderTransformer.php
@@ -22,6 +22,7 @@ class OrderTransformer extends BaseItemContainerTransformer
         /** @var Order $order */
         return array_merge(parent::transform($order), [
             'order_number' => $order->getOrderNumber(),
+            'user_id' => $order->user->id,
         ]);
     }
 }

--- a/tests/Feature/Checkout/CheckoutTest.php
+++ b/tests/Feature/Checkout/CheckoutTest.php
@@ -7,6 +7,7 @@ namespace Tipoff\Checkout\Tests\Feature\Checkout;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;
@@ -38,6 +39,9 @@ class CheckoutTest extends TestCase
         ]);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
         $this->actingAs($user);
 
         /** @var TestSellable $sellable */
@@ -90,6 +94,9 @@ class CheckoutTest extends TestCase
         ]);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
         $this->actingAs($user);
 
         /** @var TestSellable $sellable */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,18 @@ class TestCase extends BaseTestCase
 {
     protected bool $stubNovaResources = false;
 
+    protected function apiUrl(string $uri): string
+    {
+        $prefix = rtrim(config('tipoff.api.uri_prefix'), '/');
+        return ltrim("{$prefix}/{$uri}", '/');
+    }
+
+    protected function webUrl(string $uri): string
+    {
+        $prefix = rtrim(config('tipoff.web.uri_prefix'), '/');
+        return ltrim("{$prefix}/{$uri}", '/');
+    }
+
     protected function getPackageProviders($app)
     {
         return [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,12 +23,14 @@ class TestCase extends BaseTestCase
     protected function apiUrl(string $uri): string
     {
         $prefix = rtrim(config('tipoff.api.uri_prefix'), '/');
+
         return ltrim("{$prefix}/{$uri}", '/');
     }
 
     protected function webUrl(string $uri): string
     {
         $prefix = rtrim(config('tipoff.web.uri_prefix'), '/');
+
         return ltrim("{$prefix}/{$uri}", '/');
     }
 

--- a/tests/Unit/Http/Controllers/Api/CartApplyCodeControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartApplyCodeControllerTest.php
@@ -23,7 +23,7 @@ class CartApplyCodeControllerTest extends TestCase
         $this->actingAs($user);
 
         $response = $this
-            ->postJson('tipoff/cart/apply-code', [
+            ->postJson($this->apiUrl('cart/apply-code'), [
                 'code' => 'abcd',
             ])
             ->assertStatus(422);
@@ -51,7 +51,7 @@ class CartApplyCodeControllerTest extends TestCase
         $this->actingAs($user);
 
         $this
-            ->postJson('tipoff/cart/apply-code', [
+            ->postJson($this->apiUrl('cart/apply-code'), [
                 'code' => 'abcd',
             ])
             ->assertStatus(200);

--- a/tests/Unit/Http/Controllers/Api/CartApplyCodeControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartApplyCodeControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Unit\Http\Controllers\Api;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Tests\TestCase;
 use Tipoff\Support\Contracts\Checkout\CodedCartAdjustment;
@@ -43,6 +44,9 @@ class CartApplyCodeControllerTest extends TestCase
         $this->app->instance(DiscountInterface::class, $service);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         $this->actingAs($user);
 

--- a/tests/Unit/Http/Controllers/Api/CartControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartControllerTest.php
@@ -6,7 +6,6 @@ namespace Tipoff\Checkout\Tests\Unit\Http\Controllers\Api;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Authorization\Models\EmailAddress;
-use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;

--- a/tests/Unit/Http/Controllers/Api/CartControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartControllerTest.php
@@ -22,7 +22,7 @@ class CartControllerTest extends TestCase
 
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->getJson('tipoff/cart')
+        $response = $this->getJson($this->apiUrl('cart'))
             ->assertOk();
 
         $this->assertNotNull($response->json('data.item_amount_total'));
@@ -44,7 +44,8 @@ class CartControllerTest extends TestCase
 
         $this->actingAs($cart->emailAddress, 'email');
 
-        $response = $this->getJson('tipoff/cart')
+        $prefix = config('tipoff.api.uri_prefix');
+        $response = $this->getJson($this->apiUrl('cart'))
             ->assertOk();
 
         $this->assertNotNull($response->json('data.item_amount_total'));
@@ -67,7 +68,7 @@ class CartControllerTest extends TestCase
 
         $this->actingAs($cart->emailAddress, 'email');
 
-        $response = $this->getJson('tipoff/cart?include=items')
+        $response = $this->getJson($this->apiUrl('cart?include=items'))
             ->assertOk();
 
         $this->assertNotNull($response->json('data.item_amount_total'));
@@ -86,7 +87,7 @@ class CartControllerTest extends TestCase
 
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->deleteJson('tipoff/cart')
+        $response = $this->deleteJson($this->apiUrl('cart'))
             ->assertOk();
 
         $this->assertEquals('success', $response->json('data.message'));
@@ -98,7 +99,7 @@ class CartControllerTest extends TestCase
     /** @test */
     public function index_not_logged_in()
     {
-        $response = $this->getJson('tipoff/cart')
+        $response = $this->getJson($this->apiUrl('cart'))
             ->assertOk();
 
         $this->assertCount(0, $response->json('data'));
@@ -107,7 +108,7 @@ class CartControllerTest extends TestCase
     /** @test */
     public function delete_not_logged_in()
     {
-        $response = $this->deleteJson('tipoff/cart')
+        $response = $this->deleteJson($this->apiUrl('cart'))
             ->assertOk();
 
         $this->assertEquals('success', $response->json('data.message'));

--- a/tests/Unit/Http/Controllers/Api/CartControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Unit\Http\Controllers\Api;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -18,9 +19,9 @@ class CartControllerTest extends TestCase
     /** @test */
     public function index_with_no_cart()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
 
-        $this->actingAs($user);
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->getJson('tipoff/cart')
             ->assertOk();
@@ -42,7 +43,7 @@ class CartControllerTest extends TestCase
         ]);
         $cart->refresh()->save();
 
-        $this->actingAs($cart->getUser());
+        $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this->getJson('tipoff/cart')
             ->assertOk();
@@ -65,7 +66,7 @@ class CartControllerTest extends TestCase
         ]);
         $cart->refresh()->save();
 
-        $this->actingAs($cart->getUser());
+        $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this->getJson('tipoff/cart?include=items')
             ->assertOk();
@@ -80,11 +81,11 @@ class CartControllerTest extends TestCase
     /** @test */
     public function delete_json()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
         /** @var Cart $cart */
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
 
-        $this->actingAs($user);
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->deleteJson('tipoff/cart')
             ->assertOk();

--- a/tests/Unit/Http/Controllers/Api/CartItemControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartItemControllerTest.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Symfony\Component\HttpFoundation\Response;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -25,9 +26,9 @@ class CartItemControllerTest extends TestCase
         $sellable = TestSellable::factory()->create();
 
         // First user
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
         $cart = Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
         CartItem::factory()->withSellable($sellable)->count(3)->create([
             'cart_id' => $cart,
@@ -35,16 +36,16 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
 
         // Second user
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
         $cart = Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
         CartItem::factory()->withSellable($sellable)->count(4)->create([
             'cart_id' => $cart,
         ]);
         $cart->refresh()->save();
 
-        $this->actingAs($user);
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->getJson('tipoff/cart-items')
             ->assertOk();
@@ -66,7 +67,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs($cart->getUser());
+        $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this->getJson("tipoff/cart-items/{$cartItem->id}")
             ->assertOk();
@@ -88,7 +89,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
 
         $this->getJson("tipoff/cart-items/{$cartItem->id}")
             ->assertStatus(Response::HTTP_FORBIDDEN);
@@ -100,8 +101,8 @@ class CartItemControllerTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $emailAddress = EmailAddress::factory()->create();
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->postJson('tipoff/cart-items', [
             'sellable_type' => get_class($sellable),
@@ -122,8 +123,8 @@ class CartItemControllerTest extends TestCase
         TestSellable::createTable();
         $sellable = TestSellable::factory()->create();
 
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $emailAddress = EmailAddress::factory()->create();
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->postJson('tipoff/cart-items', [
             'sellable_type' => get_class($sellable),
@@ -146,8 +147,8 @@ class CartItemControllerTest extends TestCase
     /** @test */
     public function store_unknown_sellable_type()
     {
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $emailAddress = EmailAddress::factory()->create();
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->postJson('tipoff/cart-items', [
             'sellable_type' => 'notaclass',
@@ -162,8 +163,8 @@ class CartItemControllerTest extends TestCase
     /** @test */
     public function store_not_a_sellable_type()
     {
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $emailAddress = EmailAddress::factory()->create();
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->postJson('tipoff/cart-items', [
             'sellable_type' => Model::class,
@@ -180,8 +181,8 @@ class CartItemControllerTest extends TestCase
     {
         TestSellable::createTable();
 
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $emailAddress = EmailAddress::factory()->create();
+        $this->actingAs($emailAddress, 'email');
 
         $response = $this->postJson('tipoff/cart-items', [
             'sellable_type' => TestSellable::class,
@@ -208,7 +209,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs($cart->getUser());
+        $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this
             ->putJson("tipoff/cart-items/{$cartItem->id}", [
@@ -233,7 +234,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
 
         $this
             ->putJson("tipoff/cart-items/{$cartItem->id}", [
@@ -256,7 +257,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs($cart->getUser());
+        $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this->deleteJson("tipoff/cart-items/{$cartItem->id}")
             ->assertOk();
@@ -283,7 +284,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
 
         $this->deleteJson("tipoff/cart-items/{$cartItem->id}")
             ->assertStatus(Response::HTTP_FORBIDDEN);

--- a/tests/Unit/Http/Controllers/Api/CartItemControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartItemControllerTest.php
@@ -47,7 +47,7 @@ class CartItemControllerTest extends TestCase
 
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->getJson('tipoff/cart-items')
+        $response = $this->getJson($this->apiUrl('cart-items'))
             ->assertOk();
 
         $this->assertCount(4, $response->json('data'));
@@ -69,7 +69,7 @@ class CartItemControllerTest extends TestCase
 
         $this->actingAs($cart->emailAddress, 'email');
 
-        $response = $this->getJson("tipoff/cart-items/{$cartItem->id}")
+        $response = $this->getJson($this->apiUrl("cart-items/{$cartItem->id}"))
             ->assertOk();
 
         $this->assertEquals($cartItem->id, $response->json('data.id'));
@@ -91,7 +91,7 @@ class CartItemControllerTest extends TestCase
 
         $this->actingAs(EmailAddress::factory()->create(), 'email');
 
-        $this->getJson("tipoff/cart-items/{$cartItem->id}")
+        $this->getJson($this->apiUrl("cart-items/{$cartItem->id}"))
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
@@ -104,7 +104,7 @@ class CartItemControllerTest extends TestCase
         $emailAddress = EmailAddress::factory()->create();
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->postJson('tipoff/cart-items', [
+        $response = $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => get_class($sellable),
             'sellable_id' => $sellable->id,
             'item_id' => 'abc',
@@ -113,7 +113,7 @@ class CartItemControllerTest extends TestCase
 
         $this->assertEquals(1234, $response->json('data.amount_each'));
 
-        $response = $this->getJson('tipoff/cart?include=items');
+        $response = $this->getJson($this->apiUrl('cart?include=items'));
         $this->assertCount(1, $response->json('data.items.data'));
     }
 
@@ -126,7 +126,7 @@ class CartItemControllerTest extends TestCase
         $emailAddress = EmailAddress::factory()->create();
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->postJson('tipoff/cart-items', [
+        $response = $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => get_class($sellable),
             'sellable_id' => $sellable->id,
             'item_id' => 'abc',
@@ -140,7 +140,7 @@ class CartItemControllerTest extends TestCase
         $this->assertEquals('ABC', $response->json('data.tax_code'));
         $this->assertNotNull($response->json('data.expires_at'));
 
-        $response = $this->getJson('tipoff/cart?include=items');
+        $response = $this->getJson($this->apiUrl('cart?include=items'));
         $this->assertCount(1, $response->json('data.items.data'));
     }
 
@@ -150,7 +150,7 @@ class CartItemControllerTest extends TestCase
         $emailAddress = EmailAddress::factory()->create();
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->postJson('tipoff/cart-items', [
+        $response = $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => 'notaclass',
             'sellable_id' => 123,
             'item_id' => 'abc',
@@ -166,7 +166,7 @@ class CartItemControllerTest extends TestCase
         $emailAddress = EmailAddress::factory()->create();
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->postJson('tipoff/cart-items', [
+        $response = $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => Model::class,
             'sellable_id' => 123,
             'item_id' => 'abc',
@@ -184,7 +184,7 @@ class CartItemControllerTest extends TestCase
         $emailAddress = EmailAddress::factory()->create();
         $this->actingAs($emailAddress, 'email');
 
-        $response = $this->postJson('tipoff/cart-items', [
+        $response = $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => TestSellable::class,
             'sellable_id' => 123,
             'item_id' => 'abc',
@@ -212,7 +212,7 @@ class CartItemControllerTest extends TestCase
         $this->actingAs($cart->emailAddress, 'email');
 
         $response = $this
-            ->putJson("tipoff/cart-items/{$cartItem->id}", [
+            ->putJson($this->apiUrl("cart-items/{$cartItem->id}"), [
                 'quantity' => 2,
             ])
             ->assertOk();
@@ -237,7 +237,7 @@ class CartItemControllerTest extends TestCase
         $this->actingAs(EmailAddress::factory()->create(), 'email');
 
         $this
-            ->putJson("tipoff/cart-items/{$cartItem->id}", [
+            ->putJson($this->apiUrl("cart-items/{$cartItem->id}"), [
                 'quantity' => 2,
             ])
             ->assertStatus(Response::HTTP_FORBIDDEN);
@@ -259,12 +259,12 @@ class CartItemControllerTest extends TestCase
 
         $this->actingAs($cart->emailAddress, 'email');
 
-        $response = $this->deleteJson("tipoff/cart-items/{$cartItem->id}")
+        $response = $this->deleteJson($this->apiUrl("cart-items/{$cartItem->id}"))
             ->assertOk();
 
         $this->assertEquals('success', $response->json('data.message'));
 
-        $response = $this->getJson('tipoff/cart-items')
+        $response = $this->getJson($this->apiUrl('cart-items'))
             ->assertOk();
 
         $this->assertCount(3, $response->json('data'));
@@ -286,14 +286,14 @@ class CartItemControllerTest extends TestCase
 
         $this->actingAs(EmailAddress::factory()->create(), 'email');
 
-        $this->deleteJson("tipoff/cart-items/{$cartItem->id}")
+        $this->deleteJson($this->apiUrl("cart-items/{$cartItem->id}"))
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
     public function index_not_logged_in()
     {
-        $this->getJson('tipoff/cart-items')
+        $this->getJson($this->apiUrl('cart-items'))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
@@ -311,7 +311,7 @@ class CartItemControllerTest extends TestCase
         $cart->refresh()->save();
         $cartItem = $cart->cartItems->first();
 
-        $this->getJson("tipoff/cart-items/{$cartItem->id}")
+        $this->getJson($this->apiUrl("cart-items/{$cartItem->id}"))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Unit/Http/Controllers/Api/CartPurchaseControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartPurchaseControllerTest.php
@@ -29,14 +29,14 @@ class CartPurchaseControllerTest extends TestCase
         ]);
         $this->actingAs($user);
 
-        $this->postJson('tipoff/cart-items', [
+        $this->postJson($this->apiUrl('cart-items'), [
             'sellable_type' => get_class($sellable),
             'sellable_id' => $sellable->id,
             'item_id' => 'abc',
             'amount' => 1234,
         ])->assertOk();
 
-        $response = $this->postJson('tipoff/cart/purchase')
+        $response = $this->postJson($this->apiUrl('cart/purchase'))
             ->assertOk();
 
         $this->assertNotNull($response->json('data.order_number'));
@@ -53,7 +53,7 @@ class CartPurchaseControllerTest extends TestCase
         $this->actingAs($user);
 
         $response = $this
-            ->postJson('tipoff/cart/purchase')
+            ->postJson($this->apiUrl('cart/purchase'))
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $this->assertEquals('Cart is empty.', $response->json('errors.cart.0'));
@@ -83,7 +83,7 @@ class CartPurchaseControllerTest extends TestCase
         $item->save();
 
         $response = $this
-            ->postJson('tipoff/cart/purchase')
+            ->postJson($this->apiUrl('cart/purchase'))
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $this->assertEquals('Cart is empty.', $response->json('errors.cart.0'));

--- a/tests/Unit/Http/Controllers/Api/CartPurchaseControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CartPurchaseControllerTest.php
@@ -7,6 +7,7 @@ namespace Tipoff\Checkout\Tests\Unit\Http\Controllers\Api;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Symfony\Component\HttpFoundation\Response;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;
@@ -23,6 +24,9 @@ class CartPurchaseControllerTest extends TestCase
         $sellable = TestSellable::factory()->create();
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
         $this->actingAs($user);
 
         $this->postJson('tipoff/cart-items', [
@@ -42,6 +46,9 @@ class CartPurchaseControllerTest extends TestCase
     public function cannot_purchase_empty_cart()
     {
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         $this->actingAs($user);
 
@@ -58,6 +65,9 @@ class CartPurchaseControllerTest extends TestCase
         TestSellable::createTable();
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         $this->actingAs($user);
 

--- a/tests/Unit/Http/Controllers/Api/OrderControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/OrderControllerTest.php
@@ -33,7 +33,7 @@ class OrderControllerTest extends TestCase
 
         $this->actingAs($user);
 
-        $response = $this->getJson('tipoff/orders')
+        $response = $this->getJson($this->apiUrl('orders'))
             ->assertOk();
 
         $this->assertCount(4, $response->json('data'));
@@ -54,7 +54,7 @@ class OrderControllerTest extends TestCase
 
         $this->actingAs($order->getUser());
 
-        $response = $this->getJson("tipoff/orders/{$order->id}")
+        $response = $this->getJson($this->apiUrl("orders/{$order->id}"))
             ->assertOk();
 
         $this->assertEquals($order->order_number, $response->json('data.order_number'));
@@ -76,7 +76,7 @@ class OrderControllerTest extends TestCase
 
         $this->actingAs($order->getUser());
 
-        $response = $this->getJson("tipoff/orders/{$order->id}?include=items")
+        $response = $this->getJson($this->apiUrl("orders/{$order->id}?include=items"))
             ->assertOk();
 
         $this->assertEquals($order->order_number, $response->json('data.order_number'));
@@ -94,14 +94,14 @@ class OrderControllerTest extends TestCase
 
         $this->actingAs(User::factory()->create());
 
-        $this->getJson("tipoff/orders/{$order->id}")
+        $this->getJson($this->apiUrl("orders/{$order->id}"))
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
     public function index_not_logged_in()
     {
-        $this->getJson('tipoff/orders')
+        $this->getJson($this->apiUrl('orders'))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
@@ -111,7 +111,7 @@ class OrderControllerTest extends TestCase
         /** @var Order $order */
         $order = Order::factory()->create();
 
-        $this->getJson("tipoff/orders/{$order->id}")
+        $this->getJson($this->apiUrl("orders/{$order->id}"))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Unit/Http/Controllers/Api/OrderItemControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/OrderItemControllerTest.php
@@ -44,7 +44,7 @@ class OrderItemControllerTest extends TestCase
 
         $this->actingAs($user);
 
-        $response = $this->getJson('tipoff/order-items')
+        $response = $this->getJson($this->apiUrl('order-items'))
             ->assertOk();
 
         $this->assertCount(4, $response->json('data'));
@@ -66,7 +66,7 @@ class OrderItemControllerTest extends TestCase
 
         $this->actingAs($order->getUser());
 
-        $response = $this->getJson("tipoff/order-items/{$orderItem->id}")
+        $response = $this->getJson($this->apiUrl("order-items/{$orderItem->id}"))
             ->assertOk();
 
         $this->assertEquals($orderItem->id, $response->json('data.id'));
@@ -88,14 +88,14 @@ class OrderItemControllerTest extends TestCase
 
         $this->actingAs(User::factory()->create());
 
-        $this->getJson("tipoff/order-items/{$orderItem->id}")
+        $this->getJson($this->apiUrl("order-items/{$orderItem->id}"))
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
     public function index_not_logged_in()
     {
-        $this->getJson('tipoff/order-items')
+        $this->getJson($this->apiUrl('order-items'))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
@@ -113,7 +113,7 @@ class OrderItemControllerTest extends TestCase
         $order->refresh()->save();
         $orderItem = $order->orderItems->first();
 
-        $this->getJson("tipoff/order-items/{$orderItem->id}")
+        $this->getJson($this->apiUrl("order-items/{$orderItem->id}"))
             ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Unit/Models/CartModelActiveCartTest.php
+++ b/tests/Unit/Models/CartModelActiveCartTest.php
@@ -7,7 +7,6 @@ namespace Tipoff\Checkout\Tests\Unit\Models;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Authorization\Models\EmailAddress;
-use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Models\Order;

--- a/tests/Unit/Models/CartModelActiveCartTest.php
+++ b/tests/Unit/Models/CartModelActiveCartTest.php
@@ -6,6 +6,7 @@ namespace Tipoff\Checkout\Tests\Unit\Models;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -27,30 +28,30 @@ class CartModelActiveCartTest extends TestCase
     /** @test */
     public function active_cart_none_exist()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
 
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
         $this->assertNotNull($cart);
-        $this->assertEquals($user->id, $cart->user_id);
+        $this->assertEquals($emailAddress->id, $cart->email_address_id);
     }
 
     /** @test */
     public function active_cart_one_already_exist()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
 
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
 
-        $newCart = Cart::activeCart($user->id);
+        $newCart = Cart::activeCart($emailAddress->id);
         $this->assertEquals($cart->id, $newCart->id);
     }
 
     /** @test */
     public function active_cart_already_exist_with_expired_item()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
 
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
 
         // Active Item
         CartItem::factory()
@@ -60,7 +61,7 @@ class CartModelActiveCartTest extends TestCase
                 'expires_at' => Carbon::now()->addMonths(3),
             ]);
 
-        $newCart = Cart::activeCart($user->id);
+        $newCart = Cart::activeCart($emailAddress->id);
         $this->assertEquals($cart->id, $newCart->id);
 
         // Expired Item
@@ -71,23 +72,23 @@ class CartModelActiveCartTest extends TestCase
                 'expires_at' => Carbon::now()->subMinutes(3),
             ]);
 
-        $newCart = Cart::activeCart($user->id);
+        $newCart = Cart::activeCart($emailAddress->id);
         $this->assertNotEquals($cart->id, $newCart->id);
     }
 
     /** @test */
     public function active_cart_multiple_already_exist()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
         Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
         $activeCart = Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
 
         $cart = Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
         CartItem::factory()
             ->withSellable(TestSellable::factory()->create())
@@ -96,7 +97,7 @@ class CartModelActiveCartTest extends TestCase
                 'expires_at' => Carbon::now()->subMinutes(3),
             ]);
 
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
 
         $this->assertEquals($activeCart->id, $cart->id);
     }
@@ -104,16 +105,16 @@ class CartModelActiveCartTest extends TestCase
     /** @test */
     public function cart_with_order_conversion_not_active()
     {
-        $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create();
         $activeCart = Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
         ]);
         Cart::factory()->create([
-            'user_id' => $user,
+            'email_address_id' => $emailAddress,
             'order_id' => Order::factory()->create(),
         ]);
 
-        $cart = Cart::activeCart($user->id);
+        $cart = Cart::activeCart($emailAddress->id);
 
         $this->assertEquals($activeCart->id, $cart->id);
     }

--- a/tests/Unit/Policies/CartItemPolicyTest.php
+++ b/tests/Unit/Policies/CartItemPolicyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Unit\Policies;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -31,9 +32,12 @@ class CartItemPolicyTest extends TestCase
     public function all_permissions_as_owner(string $permission, bool $expected)
     {
         $user = User::factory()->create();
+        $emailAddress = EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
         $cartItem = CartItem::factory()->make([
             'cart_id' => Cart::factory()->create([
-                'user_id' => $user,
+                'email_address_id' => $emailAddress,
             ]),
         ]);
 
@@ -43,10 +47,10 @@ class CartItemPolicyTest extends TestCase
     public function data_provider_for_all_permissions_as_owner()
     {
         return [
-            'view' => [ 'view', true ],
+            'view' => [ 'view', false ],
             'create' => [ 'create', true ],
-            'update' => [ 'update', true ],
-            'delete' => [ 'delete', true ],
+            'update' => [ 'update', false ],
+            'delete' => [ 'delete', false ],
         ];
     }
 

--- a/tests/Unit/Services/Cart/CompletePurchaseTest.php
+++ b/tests/Unit/Services/Cart/CompletePurchaseTest.php
@@ -6,6 +6,7 @@ namespace Tipoff\Checkout\Tests\Unit\Services\Cart;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -35,6 +36,9 @@ class CompletePurchaseTest extends TestCase
         ]);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         /** @var Cart $cart */
         $cart = Cart::factory()->create();
@@ -67,6 +71,9 @@ class CompletePurchaseTest extends TestCase
         ]);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         /** @var Cart $cart */
         $cart = Cart::factory()->create();

--- a/tests/Unit/Services/Cart/PurchaseTest.php
+++ b/tests/Unit/Services/Cart/PurchaseTest.php
@@ -6,6 +6,7 @@ namespace Tipoff\Checkout\Tests\Unit\Services\Cart;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
+use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Services\Cart\Purchase;
@@ -40,6 +41,9 @@ class PurchaseTest extends TestCase
         ]);
 
         $user = User::factory()->create();
+        EmailAddress::factory()->create([
+            'user_id' => $user,
+        ]);
 
         /** @var Cart $cart */
         $cart = Cart::factory()->create();

--- a/tests/Unit/Services/Cart/VertifyPurchasableTest.php
+++ b/tests/Unit/Services/Cart/VertifyPurchasableTest.php
@@ -6,6 +6,8 @@ namespace Tipoff\Checkout\Tests\Unit\Services\Cart;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
+use Tipoff\Authorization\Models\EmailAddress;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Exceptions\CartNotValidException;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
@@ -29,8 +31,14 @@ class VertifyPurchasableTest extends TestCase
     /** @test */
     public function valid_cart_is_purchasable()
     {
+        $emailAddress = EmailAddress::factory()->create([
+            'user_id' => User::factory()->create(),
+        ]);
+
         /** @var Cart $cart */
-        $cart = Cart::factory()->create();
+        $cart = Cart::factory()->create([
+            'email_address_id' => $emailAddress,
+        ]);
 
         // Active Item
         CartItem::factory()
@@ -52,8 +60,14 @@ class VertifyPurchasableTest extends TestCase
             CartItemPurchaseVerification::class,
         ]);
 
+        $emailAddress = EmailAddress::factory()->create([
+            'user_id' => User::factory()->create(),
+        ]);
+
         /** @var Cart $cart */
-        $cart = Cart::factory()->create();
+        $cart = Cart::factory()->create([
+            'email_address_id' => $emailAddress,
+        ]);
 
         // Active Item
         CartItem::factory()
@@ -109,10 +123,42 @@ class VertifyPurchasableTest extends TestCase
     }
 
     /** @test */
+    public function email_must_have_user()
+    {
+        $emailAddress = EmailAddress::factory()->create([
+            'user_id' => null,
+        ]);
+
+        /** @var Cart $cart */
+        $cart = Cart::factory()->create([
+            'email_address_id' => $emailAddress,
+        ]);
+
+        // Active Item
+        CartItem::factory()
+            ->withSellable(TestSellable::factory()->create())
+            ->active()
+            ->create([
+                'cart_id' => $cart,
+            ]);
+
+        $this->expectException(CartNotValidException::class);
+
+        $handler = $this->app->make(VerifyPurchasable::class);
+        ($handler)($cart->refresh()->updatePricing());
+    }
+
+    /** @test */
     public function change_in_pricing_detected()
     {
+        $emailAddress = EmailAddress::factory()->create([
+            'user_id' => User::factory()->create(),
+        ]);
+
         /** @var Cart $cart */
-        $cart = Cart::factory()->create();
+        $cart = Cart::factory()->create([
+            'email_address_id' => $emailAddress,
+        ]);
 
         CartItem::factory()
             ->withSellable(TestSellable::factory()->create())


### PR DESCRIPTION
Requirements before merge:
* [x] update tipoff/authorization to newer version with authenticatable EmailAddress
* [x] update tipoff/locations to newer version with unambiguous routes

---

Changes cart ownership to use EmailAddress instead of User.  API Controllers support either a User being authenticated ('web' guard) or an EmailAddress being authenticated ('email' guard).

Purchasing requires the EmailAddress is linked to a User account.  The User account is not required until purchase is attempted.