### PR TITLE
Add tests for cart/checkout controllers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/authorization": "^2.8.4",
+        "tipoff/authorization": "^2.8.5",
         "tipoff/locations": "^2.10.1",
         "tipoff/statuses": "^2.2.0",
         "tipoff/support": "^2.1.3"

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -4,12 +4,12 @@
     @include('checkout::partials._cart_identity_tag')
 
     <h2>CART</h2>
-    @include('checkout::partials._errors')
+    @include('support::partials._errors')
 
     <x-tipoff-cart :cart="$cart"/>
     <x-tipoff-cart-deductions :deductions="$cart->getCodes()"/>
     <x-tipoff-cart-total :cart="$cart"/>
-    <form method="POST" action="{{ route('checkout.cart.add-code') }}">
+    <form method="POST" action="{{ route('checkout.cart-add-code') }}">
         @csrf
         <div>
             <label for="code">{{__('Code')}}</label>

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -4,7 +4,7 @@
     @include('checkout::partials._cart_identity_tag')
 
     <h2>CHECKOUT</h2>
-    @include('checkout::partials._errors')
+    @include('support::partials._errors')
 
     <x-tipoff-cart :cart="$cart"/>
     <x-tipoff-cart-deductions :deductions="$cart->getCodes()"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ Route::middleware(config('tipoff.web.middleware_group'))
         // PROTECTED ROUTES - any auth ('email' or 'web') with custom redirect
         Route::middleware(TipoffAuthenticate::class.':email,web')->group(function () {
             Route::post('cart/delete-item', [CartController::class, 'deleteItem'])->name('checkout.cart-delete-item');
-            Route::post('cart/add-code', [CartController::class, 'addCode'])->name('checkout.cart.add-code');
+            Route::post('cart/add-code', [CartController::class, 'addCode'])->name('checkout.cart-add-code');
             Route::get('cart', [CartController::class, 'show'])->name('checkout.cart-show');
 
             Route::post('checkout/purchase', [CheckoutController::class, 'purchase'])->name('checkout.purchase');

--- a/src/Models/CartItem.php
+++ b/src/Models/CartItem.php
@@ -118,11 +118,15 @@ class CartItem extends BaseModel implements CartItemInterface
         });
     }
 
-    public function isOwnerByEmailAddressId(int $emailAddressId): bool
+    public function isOwnerByEmailAddressId(?int $emailAddressId): bool
     {
-        $cart = Cart::activeCart($emailAddressId);
+        if ($emailAddressId) {
+            $cart = Cart::activeCart($emailAddressId);
 
-        return $this->cart_id === $cart->getId();
+            return $this->cart_id === $cart->getId();
+        }
+
+        return false;
     }
 
     //endregion

--- a/src/Policies/CartItemPolicy.php
+++ b/src/Policies/CartItemPolicy.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Tipoff\Authorization\Models\EmailAddress;
+use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Locations\Traits\HasLocationPermissions;
 use Tipoff\Support\Contracts\Models\UserInterface;
@@ -29,14 +31,14 @@ class CartItemPolicy
         return true;
     }
 
-    public function update(UserInterface $user, CartItem $cartItem): bool
+    public function update($userOrEmailAddress, CartItem $cartItem): bool
     {
-        return $cartItem->isOwner($user);
+        return $cartItem->isOwnerByEmailAddressId($this->getEmailAddressId($userOrEmailAddress));
     }
 
-    public function delete(UserInterface $user, CartItem $cartItem): bool
+    public function delete($userOrEmailAddress, CartItem $cartItem): bool
     {
-        return $cartItem->isOwner($user);
+        return $cartItem->isOwnerByEmailAddressId($this->getEmailAddressId($userOrEmailAddress));
     }
 
     public function restore(UserInterface $user, CartItem $cartItem): bool
@@ -47,5 +49,18 @@ class CartItemPolicy
     public function forceDelete(UserInterface $user, CartItem $cartItem): bool
     {
         return false;
+    }
+
+    private function getEmailAddressId($userOrEmailAddress): ?int
+    {
+        if ($userOrEmailAddress instanceof User) {
+            return $userOrEmailAddress->email_addresses->id ?? null;
+        }
+
+        if ($userOrEmailAddress instanceof EmailAddress) {
+            return $userOrEmailAddress->id;
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Http/Controllers/CartControllerTest.php
+++ b/tests/Unit/Http/Controllers/CartControllerTest.php
@@ -41,7 +41,7 @@ class CartControllerTest extends TestCase
         $this->actingAs(EmailAddress::factory()->create());
 
         $this->post(route('checkout.cart-add-code'), [
-            'code' => 'abcd'
+            'code' => 'abcd',
         ])
             ->assertRedirect(route('checkout.cart-show'));
     }
@@ -63,7 +63,7 @@ class CartControllerTest extends TestCase
         $this->actingAs($cart->emailAddress, 'email');
 
         $this->post(route('checkout.cart-delete-item'), [
-            'id' => $cartItem->id
+            'id' => $cartItem->id,
         ])
             ->assertRedirect(route('checkout.cart-show'));
     }
@@ -85,7 +85,7 @@ class CartControllerTest extends TestCase
         $this->actingAs(EmailAddress::factory()->create(), 'email');
 
         $this->post(route('checkout.cart-delete-item'), [
-            'id' => $cartItem->id
+            'id' => $cartItem->id,
         ])
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }

--- a/tests/Unit/Http/Controllers/CartControllerTest.php
+++ b/tests/Unit/Http/Controllers/CartControllerTest.php
@@ -5,9 +5,113 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Unit\Http\Controllers;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Symfony\Component\HttpFoundation\Response;
+use Tipoff\Authorization\Models\EmailAddress;
+use Tipoff\Checkout\Models\Cart;
+use Tipoff\Checkout\Models\CartItem;
+use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Support\Contracts\Checkout\CodedCartAdjustment;
+use Tipoff\Support\Contracts\Checkout\Discounts\DiscountInterface;
 
 class CartControllerTest extends TestCase
 {
     use DatabaseTransactions;
+
+    /** @test */
+    public function show_logged_in()
+    {
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
+
+        $this->get(route('checkout.cart-show'))
+            ->assertOk();
+    }
+
+    public function add_code_to_cart()
+    {
+        $discount = \Mockery::mock(CodedCartAdjustment::class);
+        $discount->shouldReceive('applyToCart')->once();
+
+        $service = \Mockery::mock(DiscountInterface::class);
+        $service->shouldReceive('findByCode')->twice()->andReturn($discount);
+        $service->shouldReceive('calculateAdjustments')->once();
+        $service->shouldReceive('getCodesForCart')->once()->andReturn(['abcd']);
+        $this->app->instance(DiscountInterface::class, $service);
+
+        $this->actingAs(EmailAddress::factory()->create());
+
+        $this->post(route('checkout.cart-add-code'), [
+            'code' => 'abcd'
+        ])
+            ->assertRedirect(route('checkout.cart-show'));
+    }
+
+    /** @test */
+    public function delete_cart_item_i_own()
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        /** @var Cart $cart */
+        $cart = Cart::factory()->create();
+        CartItem::factory()->withSellable($sellable)->count(4)->create([
+            'cart_id' => $cart,
+        ]);
+        $cart->refresh()->save();
+        $cartItem = $cart->cartItems->first();
+
+        $this->actingAs($cart->emailAddress, 'email');
+
+        $this->post(route('checkout.cart-delete-item'), [
+            'id' => $cartItem->id
+        ])
+            ->assertRedirect(route('checkout.cart-show'));
+    }
+
+    /** @test */
+    public function delete_cart_item_i_dont_own()
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        /** @var Cart $cart */
+        $cart = Cart::factory()->create();
+        CartItem::factory()->withSellable($sellable)->count(4)->create([
+            'cart_id' => $cart,
+        ]);
+        $cart->refresh()->save();
+        $cartItem = $cart->cartItems->first();
+
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
+
+        $this->post(route('checkout.cart-delete-item'), [
+            'id' => $cartItem->id
+        ])
+            ->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    /** @test */
+    public function show_not_logged_in()
+    {
+        $this->get(route('checkout.cart-show'))
+            ->assertRedirect(route('authorization.email-login'));
+    }
+
+    /** @test */
+    public function delete_not_logged_in()
+    {
+        $this->post(route('checkout.cart-delete-item'), [
+            'id' => 123,
+        ])
+            ->assertRedirect(route('authorization.email-login'));
+    }
+
+    /** @test */
+    public function add_code_not_logged_in()
+    {
+        $this->post(route('checkout.cart-add-code'), [
+            'code' => 'ABCD',
+        ])
+            ->assertRedirect(route('authorization.email-login'));
+    }
 }

--- a/tests/Unit/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Unit/Http/Controllers/CheckoutControllerTest.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace Tipoff\Checkout\Tests\Unit\Http\Controllers;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Symfony\Component\HttpFoundation\Response;
 use Tipoff\Authorization\Models\EmailAddress;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\CartItem;
 use Tipoff\Checkout\Tests\Support\Models\TestSellable;
 use Tipoff\Checkout\Tests\TestCase;
-use Tipoff\Support\Contracts\Checkout\CodedCartAdjustment;
-use Tipoff\Support\Contracts\Checkout\Discounts\DiscountInterface;
 
 class CheckoutControllerTest extends TestCase
 {

--- a/tests/Unit/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Unit/Http/Controllers/CheckoutControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Checkout\Tests\Unit\Http\Controllers;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Symfony\Component\HttpFoundation\Response;
+use Tipoff\Authorization\Models\EmailAddress;
+use Tipoff\Authorization\Models\User;
+use Tipoff\Checkout\Models\Cart;
+use Tipoff\Checkout\Models\CartItem;
+use Tipoff\Checkout\Tests\Support\Models\TestSellable;
+use Tipoff\Checkout\Tests\TestCase;
+use Tipoff\Support\Contracts\Checkout\CodedCartAdjustment;
+use Tipoff\Support\Contracts\Checkout\Discounts\DiscountInterface;
+
+class CheckoutControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function show_logged_in()
+    {
+        $this->actingAs(EmailAddress::factory()->create(), 'email');
+
+        $this->get(route('checkout.show'))
+            ->assertOk();
+    }
+
+    /** @test */
+    public function purchase()
+    {
+        TestSellable::createTable();
+        $sellable = TestSellable::factory()->create();
+
+        $user = User::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'email_address_id' => EmailAddress::factory()->create([
+                'user_id' => $user,
+            ]),
+        ]);
+
+        CartItem::factory()->withSellable($sellable)->count(4)->create([
+            'cart_id' => $cart,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->post(route('checkout.purchase'), [])
+            ->assertRedirect(route('checkout.confirmation'));
+    }
+
+    /** @test */
+    public function show_not_logged_in()
+    {
+        $this->get(route('checkout.show'))
+            ->assertRedirect(route('authorization.email-login'));
+    }
+
+    /** @test */
+    public function purchase_not_logged_in()
+    {
+        $this->post(route('checkout.purchase'))
+            ->assertRedirect(route('authorization.email-login'));
+    }
+
+    /** @test */
+    public function confirmation_not_logged_in()
+    {
+        $this->get(route('checkout.confirmation'))
+            ->assertRedirect(route('authorization.login'));
+    }
+}


### PR DESCRIPTION
A minor fix to CartItemPolicy to support either `User` or `EmailAddress` as logged on user, but not urgent.